### PR TITLE
fix: delete server id when shutdown server

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"os/signal"
+
 	"github.com/gofiber/fiber/v2"
 
 	"traffic-reporter/config"
@@ -8,12 +12,30 @@ import (
 )
 
 func main() {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	done := make(chan struct{})
+
 	c := config.MustNewConfig()
 
 	app := internal.InitApp(c)
 	srv := fiber.New(c.FiberConfig)
 	internal.RegisterRouters(srv, app)
+
+	go func() {
+		_ = <-sigChan
+		fmt.Println("gracefully shutting down...")
+		_ = srv.Shutdown()
+
+		done <- struct{}{}
+	}()
+
+	// ...
+
 	if err := srv.Listen(":8080"); err != nil {
 		panic(err)
 	}
+
+	<-done
+	app.Teardown()
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,12 +30,10 @@ func main() {
 		done <- struct{}{}
 	}()
 
-	// ...
-
 	if err := srv.Listen(":8080"); err != nil {
 		panic(err)
 	}
 
 	<-done
-	app.Teardown()
+	_ = app.Teardown()
 }

--- a/internal/pkg/tsid.go
+++ b/internal/pkg/tsid.go
@@ -14,6 +14,7 @@ type IDGenerator interface {
 	GenerateTSID() (int64, error)
 	ToString(int64) (string, error)
 	ToID(string) (int64, error)
+	Close() error
 }
 
 const (
@@ -92,7 +93,6 @@ func (g *TSIDGenerator) ToID(strID string) (int64, error) {
 }
 
 func (g *TSIDGenerator) Close() error {
-	ctx := context.Background()
 	g.ticker.Stop()
-	return g.rdb.Del(ctx, fmt.Sprintf("server_id:%d", g.serverID)).Err()
+	return g.rdb.Del(context.Background(), fmt.Sprintf("server_id:%d", g.serverID)).Err()
 }


### PR DESCRIPTION
서버 종료 시 id generator도 종료하며 server_id 를 반환하도록 수정.
다른 인프라 리소스도 종료하도록 추가